### PR TITLE
ADD: Participant Role

### DIFF
--- a/src/main/java/com/jaeseok/groupStudy/participant/domain/Participant.java
+++ b/src/main/java/com/jaeseok/groupStudy/participant/domain/Participant.java
@@ -2,11 +2,16 @@ package com.jaeseok.groupStudy.participant.domain;
 
 import java.util.Objects;
 
-public record Participant(Long userId, Long studyGroupId, ParticipantStatus status) {
+public record Participant(Long userId, Long studyGroupId, ParticipantStatus status, ParticipantRole role) {
 
-    // 참여 신청
+    // 참여 신청 Participant role: MEMBER
     public static Participant apply(Long participantId, Long studyGroupId) {
-        return new Participant(participantId, studyGroupId, ParticipantStatus.PENDING);
+        return new Participant(participantId, studyGroupId, ParticipantStatus.PENDING, ParticipantRole.MEMBER);
+    }
+
+    // 방 생성할 때 방장은 Participant role: HOST
+    public static Participant host(Long userId, Long studyGroupId) {
+        return new Participant(userId, studyGroupId, ParticipantStatus.APPROVED, ParticipantRole.HOST);
     }
 
     /**
@@ -38,8 +43,16 @@ public record Participant(Long userId, Long studyGroupId, ParticipantStatus stat
         return withState(ParticipantStatus.LEAVE);
     }
 
+    public boolean isHost() {
+        return this.role == ParticipantRole.HOST;
+    }
+
+    public boolean isMember() {
+        return this.role == ParticipantRole.MEMBER;
+    }
+
     private Participant withState(ParticipantStatus state) {
-        return new Participant(this.userId, this.studyGroupId, state);
+        return new Participant(this.userId, this.studyGroupId, state, this.role);
     }
 
     /**

--- a/src/main/java/com/jaeseok/groupStudy/participant/domain/ParticipantRole.java
+++ b/src/main/java/com/jaeseok/groupStudy/participant/domain/ParticipantRole.java
@@ -1,0 +1,6 @@
+package com.jaeseok.groupStudy.participant.domain;
+
+public enum ParticipantRole {
+    HOST,
+    MEMBER
+}

--- a/src/test/java/com/jaeseok/groupStudy/studyGroup/domain/StudyGroupTest.java
+++ b/src/test/java/com/jaeseok/groupStudy/studyGroup/domain/StudyGroupTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.jaeseok.groupStudy.participant.domain.Participant;
+import com.jaeseok.groupStudy.participant.domain.ParticipantRole;
 import com.jaeseok.groupStudy.participant.domain.ParticipantStatus;
 import com.jaeseok.groupStudy.studyGroup.domain.vo.StudyGroupInfo;
 import java.time.LocalDateTime;
@@ -136,11 +137,11 @@ class StudyGroupTest {
     void givenNotPendingParticipant_whenApproveParticipant_thenThrowException() {
         // given
         Participant[] invalids = {
-                new Participant(3L, studyGroup.getId(), ParticipantStatus.APPROVED),
-                new Participant(4L, studyGroup.getId(), ParticipantStatus.REJECTED),
-                new Participant(5L, studyGroup.getId(), ParticipantStatus.CANCELED),
-                new Participant(6L, studyGroup.getId(), ParticipantStatus.LEAVE),
-                new Participant(7L, studyGroup.getId(), ParticipantStatus.KICKED)
+                new Participant(3L, studyGroup.getId(), ParticipantStatus.APPROVED, ParticipantRole.MEMBER),
+                new Participant(4L, studyGroup.getId(), ParticipantStatus.REJECTED, ParticipantRole.MEMBER),
+                new Participant(5L, studyGroup.getId(), ParticipantStatus.CANCELED, ParticipantRole.MEMBER),
+                new Participant(6L, studyGroup.getId(), ParticipantStatus.LEAVE, ParticipantRole.MEMBER),
+                new Participant(7L, studyGroup.getId(), ParticipantStatus.KICKED, ParticipantRole.MEMBER)
         };
 
         // when
@@ -190,11 +191,11 @@ class StudyGroupTest {
     @DisplayName("방장이 승인 대기중이 아닌 참여자를 거절하려고 하면 예외를 던진다.")
     void givenNotPendingParticipant_whenRejectParticipant_thenThrowException() {
         // given
-        Participant approved = new Participant(3L, studyGroup.getId(), ParticipantStatus.APPROVED);
-        Participant rejected = new Participant(4L, studyGroup.getId(), ParticipantStatus.REJECTED);
-        Participant canceled = new Participant(5L, studyGroup.getId(), ParticipantStatus.CANCELED);
-        Participant leaved = new Participant(6L, studyGroup.getId(), ParticipantStatus.LEAVE);
-        Participant kicked = new Participant(7L, studyGroup.getId(), ParticipantStatus.KICKED);
+        Participant approved = new Participant(3L, studyGroup.getId(), ParticipantStatus.APPROVED, ParticipantRole.MEMBER);
+        Participant rejected = new Participant(4L, studyGroup.getId(), ParticipantStatus.REJECTED, ParticipantRole.MEMBER);
+        Participant canceled = new Participant(5L, studyGroup.getId(), ParticipantStatus.CANCELED, ParticipantRole.MEMBER);
+        Participant leaved = new Participant(6L, studyGroup.getId(), ParticipantStatus.LEAVE, ParticipantRole.MEMBER);
+        Participant kicked = new Participant(7L, studyGroup.getId(), ParticipantStatus.KICKED, ParticipantRole.MEMBER);
 
         // when
         // then


### PR DESCRIPTION
## Host, Participant 역할 통합
### 변경 배경
- 기존 Host는 StudyGroup 내 방장 역할을 담당하는 객체로, Participant와 유사한 구조임에도 불구하고 별도 객체로 존재함.
- 실제로 Host는 별도의 상태나 속성을 갖지 않으며, 역할만 다름.
- 이러한 구조는 도메인 객체 간 중복을 야기하고, 유지보수성과 일관성 측면에서 불리함.

### 변경 사항
- Participant 객체에 `ParticipantRole` 필드(`HOST`, `MEMBER`) 추가.
- 방 생성 시 방장 생성용 팩토리 메서드 `Participant.host(...)` 도입.
- 역할에 따른 권한 분기용 메서드 `isHost()`, `isMember()` 추가.
- StudyGroup은 `userId` 기준으로 `Participant`를 찾아 role로 권한 판단.

### 기대 효과
- 도메인 모델간 불필요한 분리 제거 -> 응집도 향상
- 두 모델이 따로 존재하는 것이 아니라 하나의 모델에서 역할 기반 권한 체크 방식으로 테스트 편의성과 확장성 증가
- 추후 공동 방장, 방장 위임 등 추가 기능에 대한 유연성 증가

### 주요 변경 메서드
- `Participant.host(userId, groupId)`
- `isHost()`
- `isMember()`